### PR TITLE
Update README.md NPM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ var pbf2json = require('pbf2json'),
 
 var config = {
   file: '/tmp/wellington_new-zealand.osm.pbf',
-  tags: 'addr:housenumber+addr:street',
+  tags: [
+    'addr:housenumber+addr:street'
+  ],
   leveldb: '/tmp'
 };
 


### PR DESCRIPTION
Howdy,

This PR patches the [NPM module](https://github.com/pelias/pbf2json#npm-module) example in `README.md`. When testing locally, I ran into the following error:
```txt
./node_modules/pbf2json/lib/generateParams.js:5
    const tags = config.tags.join(',');
                             ^

TypeError: config.tags.join is not a function
```

I switched the `tags` value from a string to a single item array of strings, and the example ran as expected.

Thanks!